### PR TITLE
Rely on installation instead of copy of the binary

### DIFF
--- a/.github/workflows/tests-ubuntu.yaml
+++ b/.github/workflows/tests-ubuntu.yaml
@@ -161,6 +161,7 @@ jobs:
           cmake -DBUILD_TESTING=ON -DNovapp_NDIM=1 -DNovapp_SETUP=advection_sinus -DNovapp_EOS=PerfectGas -DNovapp_GEOM=Cartesian -DNovapp_GRAVITY=Uniform -DNovapp_GTest_DEPENDENCY_POLICY=INSTALLED -DNovapp_inih_DEPENDENCY_POLICY=INSTALLED -DNovapp_Kokkos_DEPENDENCY_POLICY=INSTALLED -B build
           cmake --build build
           ctest --test-dir build --output-on-failure --timeout 5 --output-junit tests.xml
+          cmake --install build --prefix $PWD
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
         if: ( success() || failure() )  # always run even if the previous step fails

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ A straightforward way to build HERACLES++ is to assume that all dependencies are
 
 ```bash
 cmake \
-    -B build \
     -DBUILD_TESTING=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DNovapp_SETUP=shock_tube \
@@ -34,7 +33,9 @@ cmake \
     -DNovapp_EOS=PerfectGas \
     -DNovapp_GRAVITY=Uniform \
     -DNovapp_GEOM=Cartesian \
-    -DNovapp_Kokkos_DEPENDENCY_POLICY=INSTALLED
+    -DNovapp_inih_DEPENDENCY_POLICY=INSTALLED \
+    -DNovapp_Kokkos_DEPENDENCY_POLICY=INSTALLED \
+    -B build
 cmake --build build --parallel 2
 ```
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,10 +59,6 @@ target_link_libraries(
     PUBLIC inih io libnova++ MPI::MPI_CXX paraconf::paraconf PDI::PDI_C
 )
 
-add_custom_command(
-    TARGET nova++
-    POST_BUILD
-    COMMAND
-        ${CMAKE_COMMAND} -E copy $<TARGET_FILE:nova++>
-        ${PROJECT_SOURCE_DIR}/bin/nova++
-)
+include(GNUInstallDirs)
+
+install(TARGETS nova++ RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
We need to get rid of the `bin` directory:
- this automatic copy in the source directory is problematic when it is read-only,
- when multiple build directories are generated it is unclear from where the binary comes from. 