### PR TITLE
Fix a typo in the shock tube guess function

### DIFF
--- a/.github/workflows/python-checks.yaml
+++ b/.github/workflows/python-checks.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The HERACLES++ development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
 ---
 name: Python checks
 

--- a/test/exact_shock_tube.py
+++ b/test/exact_shock_tube.py
@@ -122,7 +122,7 @@ def GuessP(tabl, tabr, gamma):
             )  # Vitesse moyenne
             Ptl = 1 + g7 * (ul - u_star) / cl
             Ptr = 1 + g7 * (u_star - ur) / cr
-            P_star = (1 / 2) * (Pl * Ptr ** (1 / z) + Pr * Ptr ** (1 / z))
+            P_star = (1 / 2) * (Pl * Ptl ** (1 / z) + Pr * Ptr ** (1 / z))
         else:
             gl = np.sqrt((g5 / rhol) / (P_pvrs + g6 * Pl))
             gr = np.sqrt((g5 / rhor) / (P_pvrs + g6 * Pr))


### PR DESCRIPTION
It is confirmed by https://github.com/pmocz/riemann-solver/blob/fd2ccd47cc2cef91485b989d74668322b10e2f57/riemann-solver-python.py#L134