### PR TITLE
Set commit sha instead of version of github actions

### DIFF
--- a/.github/workflows/cmake-checks.yaml
+++ b/.github/workflows/cmake-checks.yaml
@@ -17,7 +17,7 @@ jobs:
     name: CMake format check using gersemi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install gersemi
         run: pipx install gersemi~=0.19
       - name: Run gersemi

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,14 +35,14 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
 
       - name: Log into registry ${{env.REGISTRY}}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ${{env.REGISTRY}}
           username: ${{github.actor}}
@@ -50,12 +50,12 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.7.0
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804  # v5.7.0
         with:
           images: ${{env.REGISTRY}}/${{env.IMAGE_NAME}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.15.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4  # v6.15.0
         with:
           context: ${{github.workspace}}/docker
           push: ${{github.event_name != 'pull_request'}}

--- a/.github/workflows/general-checks.yaml
+++ b/.github/workflows/general-checks.yaml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Spell Check Repo
-        uses: crate-ci/typos@v1.31.1
+        uses: crate-ci/typos@b1a1ef3893ff35ade0cfa71523852a49bfd05d19  # v1.31.1
 
   trailing-whitespaces-check:
     name: Trailing whitespaces check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - run: ./test/trailing_spaces.py --Werror $(git ls-files ':!vendor' ':!*.h5')
 
   newlines-check:
@@ -29,5 +29,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - run: ./test/newline_at_eof.py --Werror $(git ls-files ':!vendor' ':!*.h5')

--- a/.github/workflows/ini-checks.yaml
+++ b/.github/workflows/ini-checks.yaml
@@ -14,8 +14,8 @@ jobs:
     name: INI lint using validator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           cache: false
           go-version: 1.22

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -14,6 +14,6 @@ jobs:
     name: Markdown lint using markdownlint-cli2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - run: rm -rf vendor
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265  # v19.1.0

--- a/.github/workflows/packages-cleanup.yaml
+++ b/.github/workflows/packages-cleanup.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Delete old packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
         with:
           package-name: 'heraclespp'
           package-type: 'container'

--- a/.github/workflows/python-checks.yaml
+++ b/.github/workflows/python-checks.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Python format using black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install dependencies
         run: |
           pipx install black

--- a/.github/workflows/shell-checks.yaml
+++ b/.github/workflows/shell-checks.yaml
@@ -14,6 +14,6 @@ jobs:
     name: Shell lint using shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0

--- a/.github/workflows/tests-ubuntu.yaml
+++ b/.github/workflows/tests-ubuntu.yaml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     if: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: jidicula/clang-format-action@v4.15.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8  # v4.15.0
         with:
           clang-format-version: '20'
           exclude-regex: 'vendor'
@@ -39,7 +39,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Prefer 'if defined'/'if !defined' over 'ifdef'/'ifndef'
         run: if grep -RE "(ifdef|ifndef)" $(git ls-files '*.[ch]pp' ':!vendor'); then exit 1; fi
       - name: Find modifications of Kokkos reserved macros
@@ -50,7 +50,7 @@ jobs:
     container:
       image: ghcr.io/maison-de-la-simulation/heraclespp:main
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: true
       - run: |
@@ -61,7 +61,7 @@ jobs:
           cmake -B build-inih -S vendor/inih
           cmake --build build-inih
           cmake --install build-inih --prefix opt/inih
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: env-common
           path: opt
@@ -75,14 +75,14 @@ jobs:
       CXX: ${{github.workspace}}/vendor/kokkos/bin/nvcc_wrapper
       NVCC_WRAPPER_DEFAULT_COMPILER: g++-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: true
       - run: |
           cmake -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF -DKokkos_ENABLE_COMPILER_WARNINGS=ON -B build -S vendor/kokkos
           cmake --build build
           cmake --install build --prefix opt/kokkos-cuda
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: env-cuda
           path: opt
@@ -95,14 +95,14 @@ jobs:
     env:
       CXX: hipcc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: true
       - run: |
           cmake -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_ROCTHRUST=OFF -DKokkos_ARCH_AMD_GFX90A=ON -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF -DKokkos_ENABLE_COMPILER_WARNINGS=ON -B build -S vendor/kokkos
           cmake --build build
           cmake --install build --prefix opt/kokkos-hip
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: env-hip
           path: opt
@@ -113,14 +113,14 @@ jobs:
     container:
       image: ghcr.io/maison-de-la-simulation/heraclespp:main
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: true
       - run: |
           cmake -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF -DKokkos_ENABLE_DEBUG=ON -DKokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK=ON -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON -DKokkos_ENABLE_COMPILER_WARNINGS=ON -B build -S vendor/kokkos
           cmake --build build
           cmake --install build --prefix opt/kokkos-serial
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: env-serial
           path: opt
@@ -139,8 +139,8 @@ jobs:
       inih_ROOT: ${{github.workspace}}/opt/inih
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos-serial
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           path: opt
           merge-multiple: true
@@ -161,8 +161,8 @@ jobs:
       inih_ROOT: ${{github.workspace}}/opt/inih
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos-serial
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           path: opt
           merge-multiple: true
@@ -172,7 +172,7 @@ jobs:
           ctest --test-dir build --output-on-failure --timeout 5 --output-junit tests.xml
           cmake --install build --prefix $PWD
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857  # v5.5.1
         if: ( success() || failure() )  # always run even if the previous step fails
         with:
           report_paths: '${{github.workspace}}/tests.xml'
@@ -193,8 +193,8 @@ jobs:
       inih_ROOT: ${{github.workspace}}/opt/inih
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos-serial
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           path: opt
           merge-multiple: true
@@ -203,7 +203,7 @@ jobs:
           cmake --build build
           ctest --test-dir build --output-on-failure --timeout 5 --output-junit tests.xml
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857  # v5.5.1
         if: ( success() || failure() )  # always run even if the previous step fails
         with:
           report_paths: '${{github.workspace}}/tests.xml'
@@ -222,8 +222,8 @@ jobs:
       inih_ROOT: ${{github.workspace}}/opt/inih
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos-serial
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           path: opt
           merge-multiple: true
@@ -232,7 +232,7 @@ jobs:
           cmake --build build
           ctest --test-dir build --output-on-failure --timeout 5 --output-junit tests.xml
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857  # v5.5.1
         if: ( success() || failure() )  # always run even if the previous step fails
         with:
           report_paths: '${{github.workspace}}/tests.xml'
@@ -252,10 +252,10 @@ jobs:
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos-cuda
       NVCC_WRAPPER_DEFAULT_COMPILER: g++-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           path: opt
           merge-multiple: true
@@ -277,8 +277,8 @@ jobs:
       inih_ROOT: ${{github.workspace}}/opt/inih
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos-hip
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           path: opt
           merge-multiple: true
@@ -298,8 +298,8 @@ jobs:
       inih_ROOT: ${{github.workspace}}/opt/inih
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos-serial
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           path: opt
           merge-multiple: true
@@ -319,8 +319,8 @@ jobs:
       inih_ROOT: ${{github.workspace}}/opt/inih
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos-serial
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           path: opt
           merge-multiple: true
@@ -333,7 +333,7 @@ jobs:
     container:
       image: ghcr.io/maison-de-la-simulation/heraclespp:main
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: true
       - run: |

--- a/.github/workflows/yaml-checks.yaml
+++ b/.github/workflows/yaml-checks.yaml
@@ -18,7 +18,7 @@ jobs:
     name: YAML lint using yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install yamllint
         run: pipx install yamllint~=1.35
       - run: |


### PR DESCRIPTION
This PR aims to harden security following [github recommendations](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
>Pin actions to a full length commit SHA

Note that as a consequence, this will increase the number of dependabot PRs.