### PR TITLE
Remove Params from gravity and grid

### DIFF
--- a/src/gravity/gravity.hpp
+++ b/src/gravity/gravity.hpp
@@ -15,7 +15,6 @@ namespace novapp
 {
 
 class Grid;
-class Param;
 
 class UniformGravity
 {
@@ -46,7 +45,7 @@ public :
     }
 };
 
-UniformGravity make_uniform_gravity(Param const& param);
+UniformGravity make_uniform_gravity(double gx, double gy, double gz);
 
 class PointMassGravity
 {
@@ -82,7 +81,7 @@ public :
 };
 
 PointMassGravity make_point_mass_gravity(
-    Param const& param,
+    double central_mass,
     Grid const& grid);
 
 class InternalMassGravity
@@ -119,7 +118,7 @@ public :
 };
 
 InternalMassGravity make_internal_mass_gravity(
-    Param const& param,
+    double central_mass,
     Grid const& grid,
     KV_cdouble_3d const& rho);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,11 +90,11 @@ Gravity make_gravity(
         [[maybe_unused]] KV_cdouble_3d const& rho)
 {
 #if defined(NOVAPP_GRAVITY_Uniform)
-    return make_uniform_gravity(param);
+    return make_uniform_gravity(param.gx, param.gy, param.gz);
 #elif defined(NOVAPP_GRAVITY_Point_mass)
-    return make_point_mass_gravity(param, grid);
+    return make_point_mass_gravity(param.M, grid);
 #elif defined(NOVAPP_GRAVITY_Internal_mass)
-    return make_internal_mass_gravity(param, grid, rho);
+    return make_internal_mass_gravity(param.M, grid, rho);
 #endif
 }
 
@@ -144,7 +144,7 @@ void main(int argc, char** argv)
 
     Param const param(reader);
     ParamSetup const param_setup(reader);
-    Grid grid(param);
+    Grid grid(param.Nx_glob_ng, param.mpi_dims_cart, param.Ng);
 
     if (grid.mpi_rank == 0)
     {

--- a/src/mesh/grid.cpp
+++ b/src/mesh/grid.cpp
@@ -57,13 +57,13 @@ void compute_cell_center(KV_cdouble_1d const& x, KV_double_1d const& x_center)
 
 } // namespace
 
-Grid::Grid(Param const& param)
-    : Ng(param.Ng)
+Grid::Grid(std::array<int, 3> const& nx_glob_ng, std::array<int, 3> const& mpi_dims_cart, int const Ng)
+    : Ng(Ng)
     , Nghost {0, 0, 0}
-    , Nx_glob_ng(param.Nx_glob_ng)
-    , Nx_local_ng(param.Nx_glob_ng)
+    , Nx_glob_ng(nx_glob_ng)
+    , Nx_local_ng(nx_glob_ng)
     , mpi_rank_cart {0, 0, 0}
-    , mpi_dims_cart(param.mpi_dims_cart)
+    , mpi_dims_cart(mpi_dims_cart)
 {
     for (int idim = 0; idim < ndim; ++idim)
     {

--- a/src/mesh/grid.hpp
+++ b/src/mesh/grid.hpp
@@ -21,8 +21,6 @@
 namespace novapp
 {
 
-class Param;
-
 class Grid
 {
 public:
@@ -57,7 +55,7 @@ public:
     KV_double_4d ds;
     KV_double_3d dv;
 
-    explicit Grid(Param const& param);
+    Grid(std::array<int, 3> const& nx_glob_ng, std::array<int, 3> const& mpi_dims_cart, int Ng);
 
     Grid(Grid const& rhs) = delete;
 

--- a/tests/gravity.cpp
+++ b/tests/gravity.cpp
@@ -7,7 +7,6 @@
 #include <string>
 
 #include <gtest/gtest.h>
-#include <inih/INIReader.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <gravity.hpp>
@@ -15,7 +14,6 @@
 #include <grid_type.hpp>
 #include <kokkos_shortcut.hpp>
 #include <ndim.hpp>
-#include <nova_params.hpp>
 #include <range.hpp>
 #include <units.hpp>
 
@@ -39,21 +37,14 @@ void TestGravityInternalGravity()
     double const zmax = 2.356194490192345;
     double const M_star = 2E30;
 
-    INIReader const reader;
-    novapp::Param param(reader);
-    param.xmin = xmin;
-    param.xmax = xmax;
-    param.ymin = ymin;
-    param.ymax = ymax;
-    param.zmin = zmin;
-    param.zmax = zmax;
-    param.M = M_star;
-    for(int idim = 0; idim < novapp::ndim; ++idim)
-    {
-        param.Nx_glob_ng[idim] = 15;
+    std::array<int, 3> Nx_glob_ng {0, 0, 0};
+    for (int idim = 0; idim < novapp::ndim; ++idim) {
+        Nx_glob_ng[idim] = 15;
     }
+    std::array<int, 3> const mpi_dims_cart {0, 0, 0};
+    int const Ng = 2;
 
-    novapp::Grid grid(param);
+    novapp::Grid grid(Nx_glob_ng, mpi_dims_cart, Ng);
     std::unique_ptr const grid_type = std::make_unique<
             novapp::Regular>(std::array {xmin, ymin, zmin}, std::array {xmax, ymax, zmax});
 
@@ -70,7 +61,7 @@ void TestGravityInternalGravity()
     Kokkos::deep_copy(rho, rho_value);
 
     // Numerical gravitational field
-    novapp::InternalMassGravity const g = novapp::make_internal_mass_gravity(param, grid, rho);
+    novapp::InternalMassGravity const g = novapp::make_internal_mass_gravity(M_star, grid, rho);
 
     // Theoretical gravitational field
     auto xc = grid.x_center;


### PR DESCRIPTION
- Remove `Params` from `Grid`
- Remove `Params` from `make_uniform_gravity`
- Remove `Params` from `make_point_mass_gravity`
- Remove `Params` from `make_internal_mass_gravity`