### PR TITLE
Retire macOS 13

### DIFF
--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -40,10 +40,7 @@ jobs:
             c_compiler: 'clang'
             cxx_compiler: 'clang++'
         cxx_version: ['20', '23']
-        os: [macos-13, macos-14, macos-15]
-        exclude:
-          - cxx_version: '23'  # Broken mdspan integration in Kokkos
-            os: 'macos-15'
+        os: [macos-14, macos-15]
     runs-on: ${{matrix.os}}
     env:
       CXXFLAGS: -Werror=all -Werror=extra -Werror=pedantic -pedantic-errors
@@ -95,7 +92,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           repository: kokkos/kokkos
-          ref: 4.6.00
+          ref: 4.7.01
           path: kokkos
       - name: Install Kokkos
         run: |


### PR DESCRIPTION
Github will retire macOS 13 in december 2025, see https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/.